### PR TITLE
코테 세션 리스트 페이지

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@mui/base": "^5.0.0-beta.27",
         "@mui/icons-material": "^5.15.6",
         "@mui/material": "^5.15.6",
+        "@tanstack/react-query": "^5.18.1",
+        "@tanstack/react-query-devtools": "^5.18.1",
         "autoprefixer": "^10.4.16",
         "axios": "^1.6.2",
         "postcss": "^8.4.31",
@@ -1695,6 +1697,55 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.18.1.tgz",
+      "integrity": "sha512-fYhrG7bHgSNbnkIJF2R4VUXb4lF7EBiQjKkDc5wOlB7usdQOIN4LxxHpDxyE3qjqIst1WBGvDtL48T0sHJGKCw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.18.1.tgz",
+      "integrity": "sha512-U8bDnDGuwdVMT4ndegPTcjOHOmX/UOjjB7o7UalRIq3DMHLRf8Ufh4+xoAvk3LNK5GBmUBfFSw4osYe5l9n7Lw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.18.1.tgz",
+      "integrity": "sha512-PdI07BbsahZ+04PxSuDQsQvBWe008eWFk/YYWzt8fvzt2sALUM0TpAJa/DFpqa7+SSo7j1EQR6Jx6znXNHyaXw==",
+      "dependencies": {
+        "@tanstack/query-core": "5.18.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.18.1.tgz",
+      "integrity": "sha512-IrzAsodabSkEVBP0DHkuzcmqKFZ0EgG9ocuD/fRIrjYmbqqdHxzNmp2WmAZlkVo7hamA0ZdzvL5sjo1koFzjHA==",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.18.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.18.1",
+        "react": "^18.0.0"
+      }
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -6101,6 +6152,32 @@
       "integrity": "sha512-LfdGXCV9rdEify1oxlN9eamvDSjv9md9ZVMAbNHA87xqIfFCxImxan9qZ8+Un54iK2nnqPlbnSi4R54ONtbWBw==",
       "dev": true,
       "optional": true
+    },
+    "@tanstack/query-core": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.18.1.tgz",
+      "integrity": "sha512-fYhrG7bHgSNbnkIJF2R4VUXb4lF7EBiQjKkDc5wOlB7usdQOIN4LxxHpDxyE3qjqIst1WBGvDtL48T0sHJGKCw=="
+    },
+    "@tanstack/query-devtools": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.18.1.tgz",
+      "integrity": "sha512-U8bDnDGuwdVMT4ndegPTcjOHOmX/UOjjB7o7UalRIq3DMHLRf8Ufh4+xoAvk3LNK5GBmUBfFSw4osYe5l9n7Lw=="
+    },
+    "@tanstack/react-query": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.18.1.tgz",
+      "integrity": "sha512-PdI07BbsahZ+04PxSuDQsQvBWe008eWFk/YYWzt8fvzt2sALUM0TpAJa/DFpqa7+SSo7j1EQR6Jx6znXNHyaXw==",
+      "requires": {
+        "@tanstack/query-core": "5.18.1"
+      }
+    },
+    "@tanstack/react-query-devtools": {
+      "version": "5.18.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.18.1.tgz",
+      "integrity": "sha512-IrzAsodabSkEVBP0DHkuzcmqKFZ0EgG9ocuD/fRIrjYmbqqdHxzNmp2WmAZlkVo7hamA0ZdzvL5sjo1koFzjHA==",
+      "requires": {
+        "@tanstack/query-devtools": "5.18.1"
+      }
     },
     "@types/babel__core": {
       "version": "7.20.5",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@mui/base": "^5.0.0-beta.27",
     "@mui/icons-material": "^5.15.6",
     "@mui/material": "^5.15.6",
+    "@tanstack/react-query": "^5.18.1",
+    "@tanstack/react-query-devtools": "^5.18.1",
     "autoprefixer": "^10.4.16",
     "axios": "^1.6.2",
     "postcss": "^8.4.31",

--- a/src/api/session.ts
+++ b/src/api/session.ts
@@ -1,0 +1,89 @@
+export interface Session {
+  title: string;
+  problemUrl: string;
+  date: Date;
+  isPrivate: boolean;
+  isOngoing: boolean;
+}
+
+export interface SessionResponse {
+  sessions: Session[];
+  total_pages: number;
+  page: number;
+}
+
+export interface GetSessionOption {
+  keyword?: string;
+  page?: number;
+  per_page?: number;
+}
+
+const dummyItems: Session[] = [
+  {
+    title: "신나는 자바교실",
+    problemUrl: "https://google.com/",
+    date: new Date(),
+    isPrivate: true,
+    isOngoing: false,
+  },
+  {
+    title: "CSS가 뽀개질까? 내 머리가 먼저 뽀개질까?",
+    problemUrl: "https://naver.com/",
+    date: new Date(),
+    isPrivate: false,
+    isOngoing: true,
+  },
+  {
+    title: "콜백지옥과 함께 하는 즐거운 자바스크립트!",
+    problemUrl: "https://leetcode.com/",
+    date: new Date(),
+    isPrivate: true,
+    isOngoing: true,
+  },
+  {
+    title: "원숭이도 할 수 있는 타입스크립트 교실!",
+    problemUrl: "https://programmers.co.kr/",
+    date: new Date(),
+    isPrivate: false,
+    isOngoing: false,
+  },
+];
+
+const fetchSessions = async (
+  option: GetSessionOption
+): Promise<SessionResponse> => {
+  let sessions = [...dummyItems];
+  let total_pages = sessions.length;
+
+  const keyword = option.keyword;
+  const page = option.page;
+  const per_page = option.per_page;
+
+  if (keyword) {
+    sessions = dummyItems.filter(
+      (item) =>
+        item.title.includes(keyword) || item.problemUrl.includes(keyword)
+    );
+  }
+
+  if (page && per_page) {
+    const offset = (page - 1) * per_page;
+    total_pages = Math.ceil(sessions.length / per_page);
+    sessions = sessions.slice(offset, offset + per_page);
+  }
+
+  return {
+    sessions,
+    total_pages,
+    page,
+  };
+};
+
+const getSessions = async (
+  option: GetSessionOption
+): Promise<SessionResponse> => {
+  const result = await fetchSessions(option);
+  return result;
+};
+
+export { getSessions };

--- a/src/components/session/SessionAddButton.component.tsx
+++ b/src/components/session/SessionAddButton.component.tsx
@@ -1,0 +1,7 @@
+import { Button } from "@mui/material";
+
+const SessionAddButton: React.FC = () => {
+  return <Button variant="outlined">세션 +</Button>;
+};
+
+export default SessionAddButton;

--- a/src/components/session/SessionList.tsx
+++ b/src/components/session/SessionList.tsx
@@ -1,0 +1,45 @@
+import { List } from "@mui/material";
+import React from "react";
+import { useRecoilState } from "recoil";
+import { sessionKeywordState } from "../../context/session/keyword";
+import {
+  SessionPaginationProps,
+  sessionPaginationState,
+} from "../../context/session/pagination";
+import useSessionQuery from "../../queries/session";
+import SessionListItem from "./SessionListItem";
+
+const SessionList: React.FC = () => {
+  const [sessionKeyword] = useRecoilState<string>(sessionKeywordState);
+  const [{ page, per_page }] = useRecoilState<SessionPaginationProps>(
+    sessionPaginationState
+  );
+
+  const { data, isFetched } = useSessionQuery({
+    keyword: sessionKeyword,
+    page,
+    per_page,
+  });
+
+  return (
+    <List
+      sx={{ width: "100%", bgcolor: "background.paper" }}
+      aria-label="contacts"
+    >
+      {isFetched &&
+        data.sessions.map((item, index) => {
+          return (
+            <SessionListItem
+              key={index}
+              title={item.title}
+              date={item.date}
+              isPrivate={item.isPrivate}
+              isOngoing={item.isOngoing}
+            />
+          );
+        })}
+    </List>
+  );
+};
+
+export default SessionList;

--- a/src/components/session/SessionListItem.tsx
+++ b/src/components/session/SessionListItem.tsx
@@ -1,0 +1,47 @@
+import {
+  Chip,
+  ListItem,
+  ListItemButton,
+  ListItemIcon,
+  ListItemText,
+} from "@mui/material";
+import React from "react";
+
+export interface SessionItemProps {
+  title: string;
+  date: Date;
+  isPrivate: boolean;
+  isOngoing: boolean;
+}
+
+const SessionListItem: React.FC<SessionItemProps> = ({
+  title,
+  date,
+  isOngoing,
+  isPrivate,
+}) => {
+  return (
+    <ListItem disablePadding>
+      <ListItemButton sx={{ paddingX: 0 }}>
+        <ListItemIcon sx={{ justifyContent: "center", width: "72px" }}>
+          {isPrivate ? (
+            <Chip label="private" color="primary" sx={{ minWidth: "70px" }} />
+          ) : (
+            <Chip label="public" color="success" sx={{ minWidth: "70px" }} />
+          )}
+        </ListItemIcon>
+        <ListItemIcon sx={{ justifyContent: "center", width: "72px" }}>
+          {isOngoing && <Chip label="ing" color="error" />}
+        </ListItemIcon>
+
+        <ListItemText primary={title} />
+        <ListItemText
+          primary={date.toLocaleDateString()}
+          sx={{ textAlign: "end" }}
+        />
+      </ListItemButton>
+    </ListItem>
+  );
+};
+
+export default SessionListItem;

--- a/src/components/session/SessionPagination.tsx
+++ b/src/components/session/SessionPagination.tsx
@@ -1,0 +1,40 @@
+import { Box, Pagination } from "@mui/material";
+import { useCallback } from "react";
+import { useRecoilState } from "recoil";
+import { sessionKeywordState } from "../../context/session/keyword";
+import useSessionQuery from "../../queries/session";
+import {
+  SessionPaginationProps,
+  sessionPaginationState,
+} from "../../context/session/pagination";
+
+const SessionPagination: React.FC = () => {
+  const [sessionKeyword] = useRecoilState<string | null>(sessionKeywordState);
+  const [{ page, per_page }, setPagination] =
+    useRecoilState<SessionPaginationProps>(sessionPaginationState);
+
+  const { data, isFetched } = useSessionQuery({
+    keyword: sessionKeyword,
+    page,
+    per_page,
+  });
+
+  const handleChange = useCallback(
+    (_: React.ChangeEvent<unknown>, selected_page: number) =>
+      setPagination({ page: selected_page, per_page }),
+    [per_page, setPagination]
+  );
+
+  return (
+    <Box display="flex" justifyContent="center" marginY="16px">
+      <Pagination
+        count={isFetched ? data.total_pages : 1}
+        onChange={handleChange}
+        variant="outlined"
+        color="primary"
+      />
+    </Box>
+  );
+};
+
+export default SessionPagination;

--- a/src/components/session/SessionSearchBar.component.tsx
+++ b/src/components/session/SessionSearchBar.component.tsx
@@ -1,0 +1,39 @@
+import SearchIcon from "@mui/icons-material/Search";
+import { Box, IconButton, InputBase, Paper } from "@mui/material";
+import { useCallback, useRef } from "react";
+import { useRecoilState } from "recoil";
+import { sessionKeywordState } from "../../context/session/keyword";
+
+const SessionSearchBar: React.FC = () => {
+  const [, setSessionKeyword] = useRecoilState<string | null>(
+    sessionKeywordState
+  );
+  const inputRef = useRef(null);
+
+  const handleSearch = useCallback(
+    (_) => setSessionKeyword(inputRef.current.value),
+    [setSessionKeyword]
+  );
+
+  return (
+    <Box display="flex" justifyContent="end">
+      <Paper sx={{ p: "2px 4px", display: "flex", alignItems: "center" }}>
+        <InputBase
+          id="session-keyword-input"
+          inputRef={inputRef}
+          sx={{ ml: 1, flex: 1 }}
+          onKeyDown={(
+            e: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>
+          ) => {
+            if (e.key == "Enter") handleSearch(e);
+          }}
+        />
+        <IconButton type="button" sx={{ p: "10px" }} onClick={handleSearch}>
+          <SearchIcon />
+        </IconButton>
+      </Paper>
+    </Box>
+  );
+};
+
+export default SessionSearchBar;

--- a/src/components/session/SessionTitle.tsx
+++ b/src/components/session/SessionTitle.tsx
@@ -1,0 +1,7 @@
+import Typography from "@mui/material/Typography";
+
+const SessionTitle: React.FC = () => {
+  return <Typography variant="h4">스터디명 Session List</Typography>;
+};
+
+export default SessionTitle;

--- a/src/components/session/SessionUpperArea.tsx
+++ b/src/components/session/SessionUpperArea.tsx
@@ -1,0 +1,21 @@
+import { Box } from "@mui/material";
+import SessionAddButton from "./SessionAddButton.component";
+import SessionTitle from "./SessionTitle";
+
+const SessionUpperArea: React.FC = () => {
+  return (
+    <>
+      <Box
+        display="flex"
+        alignItems="center"
+        justifyContent="space-between"
+        sx={{ paddingY: "16px" }}
+      >
+        <SessionTitle />
+        <SessionAddButton />
+      </Box>
+    </>
+  );
+};
+
+export default SessionUpperArea;

--- a/src/components/session/SessionUpperArea.tsx
+++ b/src/components/session/SessionUpperArea.tsx
@@ -4,17 +4,15 @@ import SessionTitle from "./SessionTitle";
 
 const SessionUpperArea: React.FC = () => {
   return (
-    <>
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent="space-between"
-        sx={{ paddingY: "16px" }}
-      >
-        <SessionTitle />
-        <SessionAddButton />
-      </Box>
-    </>
+    <Box
+      display="flex"
+      alignItems="center"
+      justifyContent="space-between"
+      sx={{ paddingY: "16px" }}
+    >
+      <SessionTitle />
+      <SessionAddButton />
+    </Box>
   );
 };
 

--- a/src/context/session/keyword.ts
+++ b/src/context/session/keyword.ts
@@ -1,0 +1,6 @@
+import { atom } from "recoil";
+
+export const sessionKeywordState = atom({
+  key: "sessionKeyword",
+  default: null,
+});

--- a/src/context/session/pagination.ts
+++ b/src/context/session/pagination.ts
@@ -1,0 +1,14 @@
+import { atom } from "recoil";
+
+export interface SessionPaginationProps {
+  page: number;
+  per_page: number;
+}
+
+export const sessionPaginationState = atom<SessionPaginationProps>({
+  key: "sessionPagination",
+  default: {
+    page: 1,
+    per_page: 2,
+  },
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,14 +6,26 @@ import { RouterProvider } from "react-router-dom";
 import "./index.css";
 import router from "./router/index.tsx";
 
+import "@fontsource/roboto/300.css";
+import "@fontsource/roboto/400.css";
+import "@fontsource/roboto/500.css";
+import "@fontsource/roboto/700.css";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 
+const queryClient = new QueryClient();
+
 root.render(
   <RecoilRoot>
-    <React.StrictMode>
-      <RouterProvider router={router} />
-    </React.StrictMode>
+    <QueryClientProvider client={queryClient}>
+      <React.StrictMode>
+        <RouterProvider router={router} />
+      </React.StrictMode>
+      <ReactQueryDevtools initialIsOpen={false} position="bottom" />
+    </QueryClientProvider>
   </RecoilRoot>
 );

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -6,14 +6,12 @@ import SessionUpperArea from "../components/session/SessionUpperArea";
 
 const Session: React.FC = () => {
   return (
-    <>
-      <Container>
-        <SessionUpperArea />
-        <SessionList />
-        <SessionPagination />
-        <SessionSearchBar />
-      </Container>
-    </>
+    <Container>
+      <SessionUpperArea />
+      <SessionList />
+      <SessionPagination />
+      <SessionSearchBar />
+    </Container>
   );
 };
 

--- a/src/pages/Session.tsx
+++ b/src/pages/Session.tsx
@@ -1,0 +1,20 @@
+import { Container } from "@mui/material";
+import SessionList from "../components/session/SessionList";
+import SessionPagination from "../components/session/SessionPagination";
+import SessionSearchBar from "../components/session/SessionSearchBar.component";
+import SessionUpperArea from "../components/session/SessionUpperArea";
+
+const Session: React.FC = () => {
+  return (
+    <>
+      <Container>
+        <SessionUpperArea />
+        <SessionList />
+        <SessionPagination />
+        <SessionSearchBar />
+      </Container>
+    </>
+  );
+};
+
+export default Session;

--- a/src/queries/session/index.ts
+++ b/src/queries/session/index.ts
@@ -1,0 +1,23 @@
+import { UseQueryResult, useQuery } from "@tanstack/react-query";
+import {
+  GetSessionOption,
+  SessionResponse,
+  getSessions,
+} from "../../api/session";
+import { sessionQueryKey } from "./key";
+
+const useSessionQuery = (
+  option: GetSessionOption
+): UseQueryResult<SessionResponse, Error> => {
+  const result = useQuery({
+    queryKey: sessionQueryKey.keyword({
+      keyword: option.keyword,
+      page: option.page,
+      per_page: option.per_page,
+    }),
+    queryFn: () => getSessions(option),
+  });
+  return result;
+};
+
+export default useSessionQuery;

--- a/src/queries/session/key.ts
+++ b/src/queries/session/key.ts
@@ -1,0 +1,16 @@
+interface Pagination {
+  page: number;
+  per_page: number;
+}
+
+const sessionQueryKey = {
+  all: ["session"] as const,
+  keyword: ({
+    keyword,
+    page,
+    per_page,
+  }: { keyword: string | null } & Pagination) =>
+    [...sessionQueryKey.all, keyword, page, per_page] as const,
+};
+
+export { sessionQueryKey };

--- a/src/router/index.tsx
+++ b/src/router/index.tsx
@@ -1,5 +1,3 @@
-import * as React from "react";
-
 import { createBrowserRouter } from "react-router-dom";
 import LoginPage from "../pages/Login";
 import ErrorBoundary from "./errorBoundary";
@@ -9,6 +7,7 @@ import MainPage from "../pages/Main";
 import NotFound from "./NotFound";
 import StudyCreate from "../pages/StudyCreate";
 import StudyEdit from "../pages/StudyEdit";
+import Session from "../pages/Session";
 
 const router = createBrowserRouter([
   {
@@ -23,6 +22,10 @@ const router = createBrowserRouter([
   {
     path: "/chat-room",
     element: <ChatRoomPage />,
+  },
+  {
+    path: "/session",
+    element: <Session />,
   },
   {
     path: "/",


### PR DESCRIPTION
현재는 dummy session list 데이터를 가져오는 방식으로 구현해뒀고, 추후에 API 완성되면 그 부분만 수정하면 될겁니다.
interface는 어떤식으로 위치 해야 할지 몰라서 일단은 그걸 사용하는 파일에 같이 두긴 했는데, 어떤 컨벤션이 있으면 그거대로 수정해두겠습니다.

구현된 기능
- 세션 리스트 조회
- 페이지네이션
- 키워드 검색 (제목, 문제 URL)